### PR TITLE
paginationFix

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/service/InformeService.java
+++ b/src/main/java/org/springframework/samples/petclinic/service/InformeService.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.dao.DataAccessException;
 import org.springframework.samples.petclinic.model.Cita;
 import org.springframework.samples.petclinic.model.Informe;
@@ -27,6 +28,7 @@ public class InformeService {
 	}
 
 	@Transactional
+	@CacheEvict(cacheNames="findCitasPersonales", allEntries = true)
 	public void saveInforme(final Informe informe) throws DataAccessException, IllegalAccessException {
 		if (informe.getCita().getFecha().equals(LocalDate.now()) && !citaHasInforme(informe.getCita())){
 			this.informeRepository.save(informe);
@@ -41,6 +43,7 @@ public class InformeService {
 	}
 
 	@Transactional
+	@CacheEvict(cacheNames="findCitasPersonales", allEntries = true)
 	public void updateInforme(final Informe informe) throws DataAccessException, IllegalAccessException{
 		if(informe.getCita().getFecha().equals(LocalDate.now()) && citaHasInforme(informe.getCita())){
 			this.informeRepository.save(informe);
@@ -61,6 +64,7 @@ public class InformeService {
 	}
 
 	@Transactional
+	@CacheEvict(cacheNames="findCitasPersonales", allEntries = true)
 	public void deleteInforme(final int id) throws DataAccessException, IllegalAccessException{
 		Informe informe = findInformeById(id).get();
 		

--- a/src/main/java/org/springframework/samples/petclinic/web/CitaController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/CitaController.java
@@ -14,10 +14,8 @@ import org.springframework.samples.petclinic.model.Cita;
 import org.springframework.samples.petclinic.model.Medico;
 import org.springframework.samples.petclinic.model.Paciente;
 import org.springframework.samples.petclinic.service.CitaService;
-import org.springframework.samples.petclinic.service.MedicoService;
 import org.springframework.samples.petclinic.service.PacienteService;
 import org.springframework.samples.petclinic.service.UserService;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.ModelMap;
 import org.springframework.validation.BindingResult;
@@ -39,12 +37,14 @@ public class CitaController {
 	private static final String FECHA = "fecha";
 	private static final String VIEW_CITAS = "redirect:/citas";
 	
+	
 	@Autowired
 	private CitaService citaService;
 	@Autowired
 	private PacienteService pacienteService;
 	@Autowired
 	private UserService userService;
+	
 
 	// CUANDO ALGUIEN HAGA EL CITADETAILS POR FAVOR QUE USE ESTA URL EN EL MAPPING:
 	// "/citas/citaDetails/{citaId}"
@@ -59,6 +59,7 @@ public class CitaController {
 	public String listadoCitas(final ModelMap modelMap, @PathVariable("medicoId") final int medicoId) {
 		String vista = "citas/listCitas";
 		int idMedico = this.userService.getCurrentMedico().getId();
+	
 
 		if (medicoId != idMedico) {
 			return ACCESS_NOT_AUTHORIZED;
@@ -67,6 +68,7 @@ public class CitaController {
 			if (citas.isEmpty()) {
 				return "redirect:/";
 			} else {
+				
 				modelMap.put("selections", citas);
 				modelMap.put("dateOfToday", LocalDate.now());
 				return vista;

--- a/src/main/java/org/springframework/samples/petclinic/web/InformeController.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/InformeController.java
@@ -105,12 +105,14 @@ public class InformeController {
 
 			Boolean canBeDeleted = informe.getCita().getFecha().plusDays(1).equals(LocalDate.now().plusDays(1)) && informe.getHistoriaClinica() == null;
 			mav.getModel().put("cannotbedeleted", !canBeDeleted);
-
+			
+			if(informe.getTratamientos() != null){
 			Page<Tratamiento> tratamientos = this.tratamientoService.findTrata(informeId, pageable);
 			
 			mav.getModel().put("editTratamientoOk", cita.getFecha().equals(LocalDate.now()));
 			mav.getModel().put("tratamientos", tratamientos.getContent());
 			mav.getModel().put("tratapages", tratamientos.getTotalPages()-1);
+				}
 
 			Boolean canBeEdited = informe.getCita().getFecha().equals(LocalDate.now());
 			mav.getModel().put("canbeedited", canBeEdited);

--- a/src/main/resources/db/hsqldb/data.sql
+++ b/src/main/resources/db/hsqldb/data.sql
@@ -116,6 +116,8 @@ INSERT INTO cita VALUES (9, 'Cita Test Pasado Informes', '2020-04-20', 'Consulta
 INSERT INTO cita VALUES (10, 'Cita Test Pasado PacienteIntegration', '2015-04-20', 'ConsultaTEST', 8);
 INSERT INTO cita VALUES (11, 'Cita Test Pasado PacienteIntegration2', '2013-04-20', 'ConsultaTEST', 9);
 INSERT INTO cita VALUES (12, 'Cita Test Pasado PacienteIntegration3', '2015-05-26', 'ConsultaTEST', 6);
+INSERT INTO cita VALUES (13, 'nombre4', CURRENT_TIMESTAMP ,'Probando',1);
+
 
 INSERT INTO historiaclinica(id,descripcion,paciente_id) VALUES (1,'Descripcion',1);
 INSERT INTO historiaclinica(id,descripcion,paciente_id) VALUES (2,'Descripcion 2',2);
@@ -130,6 +132,7 @@ INSERT INTO informe (id,motivo_consulta,diagnostico,cita_id,historia_clinica_id)
 INSERT INTO informe (id,motivo_consulta,diagnostico,cita_id,historia_clinica_id) VALUES (3, 'cita pasada', 'cita past',9,null);
 
 INSERT INTO informe (id,motivo_consulta,diagnostico,cita_id,historia_clinica_id) VALUES (4, 'cita nueva', 'cita nueva',10,null);
+INSERT INTO informe (id,motivo_consulta,diagnostico,cita_id,historia_clinica_id) VALUES (5, 'cita nueva', 'cita nueva',13,null);
 
 
 INSERT INTO tratamiento(id,name,medicamento,dosis,f_inicio_tratamiento,f_fin_tratamiento,informe_id) 
@@ -148,3 +151,7 @@ INSERT INTO tratamiento(id,name,medicamento,dosis,f_inicio_tratamiento,f_fin_tra
 VALUES (6, 'nombre6','paracetamol','1 cada dos horas','2020-03-09','2020-12-15',4);
 INSERT INTO tratamiento(id,name,medicamento,dosis,f_inicio_tratamiento,f_fin_tratamiento,informe_id) 
 VALUES (7, 'nombre7','enantium','1 cada tres dias','2020-03-09','2020-12-15',4);
+INSERT INTO tratamiento(id,name,medicamento,dosis,f_inicio_tratamiento,f_fin_tratamiento,informe_id) 
+VALUES (8, 'nombre7','enantium','1 cada tres dias',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,5);
+INSERT INTO tratamiento(id,name,medicamento,dosis,f_inicio_tratamiento,f_fin_tratamiento,informe_id) 
+VALUES (9, 'nombre5','alprazolam','1 cada tres dias','2020-01-19','2020-03-10',1);

--- a/src/main/resources/db/mysql/data.sql
+++ b/src/main/resources/db/mysql/data.sql
@@ -152,3 +152,6 @@ INSERT INTO tratamiento(id,name,medicamento,dosis,f_inicio_tratamiento,f_fin_tra
 VALUES (7, 'nombre7','enantium','1 cada tres dias','2020-03-09','2020-12-15',4);
 INSERT INTO tratamiento(id,name,medicamento,dosis,f_inicio_tratamiento,f_fin_tratamiento,informe_id) 
 VALUES (8, 'nombre7','enantium','1 cada tres dias',CURRENT_TIMESTAMP,CURRENT_TIMESTAMP,5);
+
+INSERT INTO tratamiento(id,name,medicamento,dosis,f_inicio_tratamiento,f_fin_tratamiento,informe_id) 
+VALUES (9, 'nombre5','alprazolam','1 cada tres dias','2020-01-19','2020-03-10',1);

--- a/src/main/webapp/WEB-INF/jsp/informes/informeDetails.jsp
+++ b/src/main/webapp/WEB-INF/jsp/informes/informeDetails.jsp
@@ -28,7 +28,7 @@
 		</tr>
 	</table>
 
-	<c:if test="${cannotbedeleted==false}">
+	<c:if test="${cannotbedeleted==false && tratamientos.isEmpty()}">
 		<spring:url value="/citas/{citaId}/informes/delete/{informeId}" var="deleteUrl">
 			<spring:param name="informeId" value="${informe.id}" />
 			<spring:param name="citaId" value="${informe.cita.id}"/>
@@ -124,12 +124,14 @@
     </table>
 	</c:if>
 	
+	<c:if test="${!tratamientos.isEmpty()}">
 	<c:forEach begin="0" end="${tratapages}" var="current">
 		<spring:url value="../informes/{informeId}?page=${current}" var="pageUrl">
 		<spring:param name="informeId" value="${informe.id}" />
 		</spring:url>
 	<a href="${fn:escapeXml(pageUrl)}" class="btn btn-default">Pagina ${current+1}</a>
 	</c:forEach>
+	</c:if>
 	<br>
 	<br>
     <c:if test="${editTratamientoOk}">
@@ -138,4 +140,5 @@
 	</spring:url>
 	<a href="${fn:escapeXml(createTratUrl)}" class="btn btn-default">Crear Tratamiento</a>
 	</c:if>
+
 </petclinic:layout>

--- a/src/test/java/org/springframework/samples/petclinic/service/TratamientoServiceTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/service/TratamientoServiceTest.java
@@ -110,7 +110,7 @@ public class TratamientoServiceTest {
 	@Test
 	public void testCountWithInitialData() {
 		int count = this.tratamientoService.tratamientoCount();
-		Assertions.assertEquals(count, 8);
+		Assertions.assertEquals(count, 9);
 	}
 	
 

--- a/src/test/java/org/springframework/samples/petclinic/web/e2e/TestInformeControladorE2E.java
+++ b/src/test/java/org/springframework/samples/petclinic/web/e2e/TestInformeControladorE2E.java
@@ -395,6 +395,21 @@ public class TestInformeControladorE2E {
 
 	}
 
+	@WithMockUser(username = "alvaroMedico", authorities = {"medico"})
+	@Test
+	void testShowInformeWithManyTratamientos() throws Exception{
+		this.mockMvc.perform(MockMvcRequestBuilders.get("/citas/{citaId}/informes/{informeId}", 1, 1))
+		.andExpect(MockMvcResultMatchers.status().isOk())
+			.andExpect(MockMvcResultMatchers.view().name("informes/informeDetails"))
+			.andExpect(MockMvcResultMatchers.model().attributeExists("informe"))
+			.andExpect(MockMvcResultMatchers.model().attribute("cannotbedeleted", true))
+			.andExpect(MockMvcResultMatchers.model().attribute("canbeedited", false))
+			.andExpect(MockMvcResultMatchers.model().attribute("editTratamientoOk", false))
+			.andExpect(MockMvcResultMatchers.model().attributeExists("tratamientos"))
+			.andExpect(MockMvcResultMatchers.model().attribute("tratapages", 1)
+			);
+	}
+
 	@WithMockUser(username = "alvaroMedico", authorities = {
 		"medico"
 	})


### PR DESCRIPTION
-Renombrado del metodo showInforme a showInformeWithoutTratamientos
-Dos tests nuevos de controlador: showInformeWithTratamiento y showInformeWith2PagesTratamientos
-Un test nuevo E2E: showInformeWithManyTratamientos
-Un tratamiento nuevo añadido a la primera cita del paciente 1 en Data.sql
-Correspondiente cambio en el count de los test de Servicio de Tratamiento
-Equiparación de Data.sql de MysqlDB al Data.sql H2 (Estaba desactualizado)
-Refresco de caché en el servicio de Informe

Problemas encontrados:
-El paciente que se suponia que era para borrar tiene una cita en pasado, aún así le aparece el botón de borrar en el Details. Cuando intentas borrarlo por supuesto salta excepción y no lo borra.
-Hay partes de Cita Controller que no tienen coverage completo, esto no es nuevo. En el último Sonar ya aparecía (1 de Junio)
-Cuando se edita un informe, se desliga de Historia Clinica ¿Esto es intencionado?